### PR TITLE
Add support for Scala 2.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .cache
 .history
 .idea
+.metals
+.bloop
 .lib/
 dist/*
 target/

--- a/build.sbt
+++ b/build.sbt
@@ -2,19 +2,23 @@ organization := "com.github.tkqubo"
 
 name := "html-to-markdown"
 
-scalaVersion := "2.12.3"
+val scala211 = "2.11.12"
+val scala212 = "2.12.8"
+val scala213 = "2.13.0"
 
-crossScalaVersions := Seq("2.12.3", "2.11.11")
+scalaVersion := scala212
 
-val specs2Ver = "3.9.5"
-val jsoupVer = "1.10.3"
+crossScalaVersions := Seq(scala211, scala212, scala213)
+
+val specs2Ver = "4.6.0"
+val jsoupVer = "1.12.1"
 
 libraryDependencies ++= Seq(
   "org.jsoup" % "jsoup" % jsoupVer,
-  "org.specs2" %% "specs2-core" % specs2Ver % "test",
-  "org.specs2" %% "specs2-matcher" % specs2Ver % "test",
-  "org.specs2" %% "specs2-matcher-extra" % specs2Ver % "test",
-  "org.specs2" %% "specs2-mock" % specs2Ver % "test"
+  "org.specs2" %% "specs2-core" % specs2Ver % Test,
+  "org.specs2" %% "specs2-matcher" % specs2Ver % Test,
+  "org.specs2" %% "specs2-matcher-extra" % specs2Ver % Test,
+  "org.specs2" %% "specs2-mock" % specs2Ver % Test
 )
 
 javaOptions in Test ++= Seq(

--- a/circle.yml
+++ b/circle.yml
@@ -14,16 +14,19 @@ general:
 dependencies:
   cache_directories:
     - "~/.sbt"
+    - "~/.ivy2/cache"
+    - "~/.m2"
   override:
     - echo "N/A"
 test:
   pre:
+    - export SBT_VERSION="1.2.8"
     - sudo apt-get update
     - sudo apt-get install wget
-    - sudo wget -o sbt.zip https://github.com/sbt/sbt/releases/download/v1.0.1/sbt-1.0.1.zip
-    - sudo unzip sbt-1.0.1.zip
-    - sudo mkdir -p /home/ubuntu/.sbt/.lib/1.0.1/
-    - sudo mv sbt/bin/sbt-launch.jar /home/ubuntu/.sbt/.lib/1.0.1/
+    - sudo wget -o sbt.zip https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.zip
+    - sudo unzip sbt-$SBT_VERSION.zip
+    - sudo mkdir -p /home/ubuntu/.sbt/.lib/$SBT_VERSION/
+    - sudo mv sbt/bin/sbt-launch.jar /home/ubuntu/.sbt/.lib/$SBT_VERSION/
   override:
     - cat /dev/null | sbt scalastyle clean coverage test coverageReport
   post:

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.1
+sbt.version=1.2.8

--- a/src/main/scala/com/github/tkqubo/html2md/Html2Markdown.scala
+++ b/src/main/scala/com/github/tkqubo/html2md/Html2Markdown.scala
@@ -5,7 +5,7 @@ import com.github.tkqubo.html2md.helpers.NodeOps._
 import org.jsoup.Jsoup
 import org.jsoup.nodes._
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
 /**
@@ -42,9 +42,9 @@ class Html2Markdown(val converter: MarkdownConverter) {
       var e: Node = inQueue.head
       inQueue = inQueue.tail
       outQueue += e
-      inQueue ++= e.childNodes()
+      inQueue ++= e.childNodes().asScala
     }
-    outQueue.tail
+    outQueue.tail.toSeq
   }
 }
 

--- a/src/main/scala/com/github/tkqubo/html2md/converters/DefaultMarkdownConverter.scala
+++ b/src/main/scala/com/github/tkqubo/html2md/converters/DefaultMarkdownConverter.scala
@@ -4,7 +4,7 @@ import com.github.tkqubo.html2md.ConversionRule
 import com.github.tkqubo.html2md.helpers.NodeOps._
 import org.jsoup.nodes.Element
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 /**
   * Converts html text into markdown
@@ -54,8 +54,8 @@ class DefaultMarkdownConverter extends MarkdownConverter {
 
     // code blocks
     { e: Element =>
-      e.tagName() == "pre" && e.children().headOption.exists(_.tagName() == "code")
-    } -> { e: Element => s"\n\n    ${e.children().head.text.replaceAll("\n", "\n    ")}\n\n" },
+      e.tagName() == "pre" && e.children().asScala.headOption.exists(_.tagName() == "code")
+    } -> { e: Element => s"\n\n    ${e.children().asScala.head.text.replaceAll("\n", "\n    ")}\n\n" },
 
     'blockquote -> { content: String =>
       val replacement = content
@@ -83,6 +83,7 @@ class DefaultMarkdownConverter extends MarkdownConverter {
     Seq('ul, 'ol) -> { (content: String, e: Element) =>
       val children = e
         .children
+        .asScala
         .filter(_.tagName == "li")
         .map(_.markdown)
         .mkString("\n")

--- a/src/main/scala/com/github/tkqubo/html2md/converters/GitHubFlavoredMarkdownConverter.scala
+++ b/src/main/scala/com/github/tkqubo/html2md/converters/GitHubFlavoredMarkdownConverter.scala
@@ -2,7 +2,7 @@ package com.github.tkqubo.html2md.converters
 
 import com.github.tkqubo.html2md.ConversionRule
 import org.jsoup.nodes.{Node, Element}
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 
 /**
@@ -28,7 +28,7 @@ class GitHubFlavoredMarkdownConverter
         .map(_.trim + " ")
         .mkString("").trim
       if (e.parent.tagName == "thead") {
-        val borderCells = e.children.map { head =>
+        val borderCells = e.children.asScala.map { head =>
           val align = Option(head.attr("align"))
           val marker = align match {
             case Some("left") => ":--"
@@ -56,8 +56,8 @@ class GitHubFlavoredMarkdownConverter
     Seq('thead, 'tbody, 'tfoot) -> { content: String => content.trim },
 
     // fenced code blocks
-    { e: Element => e.tagName == "pre" && e.children.headOption.exists(_.tagName == "code") } ->
-      { e: Element => s"\n\n```\n${e.children.head.text}```\n\n" },
+    { e: Element => e.tagName == "pre" && e.children.asScala.headOption.exists(_.tagName == "code") } ->
+      { e: Element => s"\n\n```\n${e.children.asScala.head.text}```\n\n" },
 
     // syntax-highlighted code blocks
     { e: Element => e.tagName == "pre" && e.parent.tagName == "div" && hasHighlight(e.parent) } -> { e: Element =>

--- a/src/main/scala/com/github/tkqubo/html2md/helpers/NodeOps.scala
+++ b/src/main/scala/com/github/tkqubo/html2md/helpers/NodeOps.scala
@@ -2,7 +2,7 @@ package com.github.tkqubo.html2md.helpers
 
 import org.jsoup.nodes.{Element, Node, TextNode}
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 object NodeOps {
   /** Node's attribute name that hold a markdown text */
@@ -24,7 +24,7 @@ object NodeOps {
         case node: Element if node.hasAttr(markdownAttribute) =>
           node.attr(markdownAttribute)
         case node: Element =>
-          node.childNodes
+          node.childNodes.asScala
             .map(_.markdown)
             .reduceLeftOption(_ + _)
             .getOrElse("")


### PR DESCRIPTION
- Remove deprecated `scala.collection.JavaConversions`
- Add `scala.collection.JavaConverters`
- Clean up build and update dependencies